### PR TITLE
Default array() type for target argument

### DIFF
--- a/src/Idephix/Idephix.php
+++ b/src/Idephix/Idephix.php
@@ -26,7 +26,7 @@ class Idephix implements IdephixInterface
     protected $currentHost;
     protected $invokerClassName;
 
-    public function __construct(array $targets = null, SshClient $sshClient = null, OutputInterface $output = null, InputInterface $input = null)
+    public function __construct(array $targets = array(), SshClient $sshClient = null, OutputInterface $output = null, InputInterface $input = null)
     {
         $this->application = new Application('Idephix', self::VERSION);
         $this->targets = $targets;


### PR DESCRIPTION
This PR fixes the PHP warnings:

```
PHP Warning:  array_keys() expects parameter 1 to be array, null given in /.../Idephix/src/Idephix/Idephix.php on line 113
PHP Warning:  implode(): Invalid arguments passed in /.../Idephix/src/Idephix/Idephix.php on line 113
```

thrown if idxfile doesn't contain any environment. 
