### PR TITLE
Added custom port number to rsync command

### DIFF
--- a/src/Idephix/Extension/Project/Project.php
+++ b/src/Idephix/Extension/Project/Project.php
@@ -8,7 +8,6 @@ use Idephix\Extension\IdephixAwareInterface;
 /**
  * @todo:
  * - allow for $exclude to be an array
- * - manage ports different from the default one
  * - check to undefined params in currentTarget
  */
 class Project implements IdephixAwareInterface
@@ -37,12 +36,18 @@ class Project implements IdephixAwareInterface
 
         $user = $target->get('ssh_params.user');
         $host = $this->idx->getCurrentTargetHost();
+        $port = $target->get('ssh_params.port');
 
         if (file_exists($exclude)) {
             $extraOpts .= ' --exclude-from='.$exclude;
         }
 
-        $cmd = "rsync -rlDcz --force --delete --progress $extraOpts -e 'ssh' $localDir $user@$host:$remoteDir";
+        $sshCmd = 'ssh';
+        if ($port) {
+            $sshCmd .= ' -p ' . $port;
+        }
+
+        $cmd = "rsync -rlDcz --force --delete --progress $extraOpts -e '$sshCmd' $localDir $user@$host:$remoteDir";
 
         return $this->idx->local($cmd);
     }

--- a/tests/Idephix/Extension/Project/ProjectTest.php
+++ b/tests/Idephix/Extension/Project/ProjectTest.php
@@ -17,10 +17,6 @@ class ProjectTest extends \PHPUnit_Framework_TestCase
              ->will($this->returnArgument(0));
 
         $this->idx->expects($this->exactly(1))
-             ->method('getCurrentTarget')
-             ->will($this->returnValue(new Config(array('ssh_params' => array('user' => 'kea')))));
-
-        $this->idx->expects($this->exactly(1))
              ->method('getCurrentTargetHost')
              ->will($this->returnValue('banana.com'));
 
@@ -31,9 +27,24 @@ class ProjectTest extends \PHPUnit_Framework_TestCase
 
     public function testRsyncProject()
     {
+        $this->idx->expects($this->exactly(1))
+          ->method('getCurrentTarget')
+          ->will($this->returnValue(new Config(array('ssh_params' => array('user' => 'kea')))));
+
         $result = $this->project->rsyncProject('/a/remote', './from');
 
         $this->assertEquals("rsync -rlDcz --force --delete --progress  -e 'ssh' ./from kea@banana.com:/a/remote/", $result);
+    }
+
+    public function testRsyncProjectWithCustomPort()
+    {
+        $this->idx->expects($this->exactly(1))
+          ->method('getCurrentTarget')
+          ->will($this->returnValue(new Config(array('ssh_params' => array('user' => 'kea', 'port' => 20817)))));
+
+        $result = $this->project->rsyncProject('/a/remote', './from');
+
+        $this->assertEquals("rsync -rlDcz --force --delete --progress  -e 'ssh -p 20817' ./from kea@banana.com:/a/remote/", $result);
     }
 
 }


### PR DESCRIPTION
This PR adds the ability to use a custom port number for rsync command.
