### PR TITLE
Avoid ide related stuff in gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,5 @@ idxfile.php
 idxfile_custom.php
 junit.xml
 bin/idephix.phar
-nbproject/
-.idea
 phpunit.xml
 bin/phpunit


### PR DESCRIPTION
I guess we should avoid IDE or OS related stuff in our `.gitignore`
If you need to exclude this kind of stuff you can use your `~/.gitignore_global` 

Also I'm not sure about `idxfile_custom.php` `bin/idephix.phar` who's generating them? Should we ignore them?