### PR TITLE
Preserve my current deploy

### DIFF
--- a/src/Idephix/Extension/Deploy/Deploy.php
+++ b/src/Idephix/Extension/Deploy/Deploy.php
@@ -241,11 +241,15 @@ class Deploy implements IdephixAwareInterface
      */
     public function deleteOldReleases($releasesToKeep)
     {
-        return $this->idx->remote(
+        if (!is_numeric($releasesToKeep) || $releasesToKeep < 2) {
+            return;
+        }
+        $this->idx->remote(
             sprintf(
-                "cd %s && ls | sort | head -n -%d | xargs rm -Rf",
+                "cd %s && ls | sort | grep -v $(basename $(readlink %s)) | head -n -%d | xargs rm -Rf",
                 escapeshellarg($this->releasesFolder),
-                $releasesToKeep
+                escapeshellarg($this->getCurrentReleaseFolder()),
+                $releasesToKeep - 1
             ),
             $this->dryRun
         );

--- a/tests/Idephix/Extension/Deploy/DeployTest.php
+++ b/tests/Idephix/Extension/Deploy/DeployTest.php
@@ -90,7 +90,7 @@ Remote: cd $nextReleaseDir && ./app/console cache:clear --env=dev --no-debug
 Asset and assetic stuff...
 Remote: cd $nextReleaseDir && php app/console assets:install --symlink web --env=dev
 Remote: cd $nextReleaseDir && php app/console assetic:dump --env=dev --no-debug
-Remote: cd '/tmp/temp_dir/releases/' && ls | sort | head -n -6 | xargs rm -Rf
+Remote: cd '/tmp/temp_dir/releases/' && ls | sort | grep -v $(basename $(readlink '$currentReleaseDir')) | head -n -5 | xargs rm -Rf
 Switch to next release...
 Remote: cd /tmp/temp_dir/ && ln -s releases/$nextReleaseName next && mv -fT next current
 ";
@@ -139,7 +139,7 @@ Remote: cd $nextReleaseDir && ./app/console cache:clear --env=prod --no-debug
 Asset and assetic stuff...
 Remote: cd $nextReleaseDir && php app/console assets:install --symlink web --env=prod
 Remote: cd $nextReleaseDir && php app/console assetic:dump --env=prod --no-debug
-Remote: cd '/tmp/temp_dir/releases/' && ls | sort | head -n -6 | xargs rm -Rf
+Remote: cd '/tmp/temp_dir/releases/' && ls | sort | grep -v $(basename $(readlink '$currentReleaseDir')) | head -n -5 | xargs rm -Rf
 Switch to next release...
 Remote: cd /tmp/temp_dir/ && ln -s releases/$nextReleaseName next && mv -fT next current
 ";
@@ -204,7 +204,7 @@ Remote: cd $nextReleaseDir && ./app/console doctrine:migration:migrate --env=dev
 Asset and assetic stuff...
 Remote: cd $nextReleaseDir && php app/console assets:install --symlink web --env=dev
 Remote: cd $nextReleaseDir && php app/console assetic:dump --env=dev --no-debug
-Remote: cd '/tmp/temp_dir/releases/' && ls | sort | head -n -6 | xargs rm -Rf
+Remote: cd '/tmp/temp_dir/releases/' && ls | sort | grep -v $(basename $(readlink '$currentReleaseDir')) | head -n -5 | xargs rm -Rf
 Switch to next release...
 Remote: cd /tmp/temp_dir/ && ln -s releases/$nextReleaseName next && mv -fT next current
 ";


### PR DESCRIPTION
Putting "grep -v $(basename $(readlink %s))" between "sort" and "head" should fix #56
We also need to pass ($releasesToKeep - 1) to "head -n -%d" because we always grep one result from "sort".
