### PR TITLE
Adds .gitattributes for ignoring files in archives

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,11 @@
+# Path-based git attributes
+# https://www.kernel.org/pub/software/scm/git/docs/gitattributes.html
+
+# Ignore all test and documentation with "export-ignore".
+/.gitattributes             export-ignore
+/.gitignore                 export-ignore
+/.travis.yml                export-ignore
+/phpunit.xml.dist           export-ignore
+/tests                      export-ignore
+/id_rsa_idephix_doc.enc     export-ignore
+/bin/idephix.phar           export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -5,7 +5,6 @@
 /.gitattributes             export-ignore
 /.gitignore                 export-ignore
 /.travis.yml                export-ignore
-/phpunit.xml.dist           export-ignore
 /tests                      export-ignore
 /id_rsa_idephix_doc.enc     export-ignore
 /bin/idephix.phar           export-ignore


### PR DESCRIPTION
Following this suggestion: https://github.com/puli/issues/issues/124

Some files can simply be ignored when creating the archive version of the repo. When installing the library via composer with the `--prefer-dist`