### PR TITLE
Fix travis in pull requests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ php:
 before_script:
   - composer self-update
   - mkdir -p ~/.ssh
-  - '[ "${TRAVIS_PULL_REQUEST}" = "false" ] && openssl aes-256-cbc -K $encrypted_6ab1bc8a1906_key -iv $encrypted_6ab1bc8a1906_iv -in id_rsa_idephix_doc.enc -out ~/.ssh/id_rsa -d'
+  - openssl aes-256-cbc -K $encrypted_6ab1bc8a1906_key -iv $encrypted_6ab1bc8a1906_iv -in id_rsa_idephix_doc.enc -out ~/.ssh/id_rsa -d'
 
 script: bin/idephix.phar buildTravis
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ php:
 before_script:
   - composer self-update
   - mkdir -p ~/.ssh
-  - openssl aes-256-cbc -K $encrypted_6ab1bc8a1906_key -iv $encrypted_6ab1bc8a1906_iv -in id_rsa_idephix_doc.enc -out ~/.ssh/id_rsa -d'
+  - openssl aes-256-cbc -K $encrypted_6ab1bc8a1906_key -iv $encrypted_6ab1bc8a1906_iv -in id_rsa_idephix_doc.enc -out ~/.ssh/id_rsa -d
 
 script: bin/idephix.phar buildTravis
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,6 @@ php:
 
 before_script:
   - composer self-update
-  - mkdir -p ~/.ssh
-  - openssl aes-256-cbc -K $encrypted_6ab1bc8a1906_key -iv $encrypted_6ab1bc8a1906_iv -in id_rsa_idephix_doc.enc -out ~/.ssh/id_rsa -d
 
 script: bin/idephix.phar buildTravis
 
@@ -16,6 +14,8 @@ after_script:
   - bin/test-reporter --coverage-report=clover.xml
 
 after_success:
+  - mkdir -p ~/.ssh
+  - '[ "${TRAVIS_PULL_REQUEST}" = "false" ] && openssl aes-256-cbc -K $encrypted_6ab1bc8a1906_key -iv $encrypted_6ab1bc8a1906_iv -in id_rsa_idephix_doc.enc -out ~/.ssh/id_rsa -d'
   - '[ "${TRAVIS_PULL_REQUEST}" = "false" ] && bin/idephix.phar deployPhar'
 
 branches:


### PR DESCRIPTION
Actually every time travis run a pull requests branch it fails with error:

```
$ [ "${TRAVIS_PULL_REQUEST}" = "false" ] && openssl aes-256-cbc -K $encrypted_6ab1bc8a1906_key -iv $encrypted_6ab1bc8a1906_iv -in id_rsa_idephix_doc.enc -out ~/.ssh/id_rsa -d

The command "[ "${TRAVIS_PULL_REQUEST}" = "false" ] && openssl aes-256-cbc -K $encrypted_6ab1bc8a1906_key -iv $encrypted_6ab1bc8a1906_iv -in id_rsa_idephix_doc.enc -out ~/.ssh/id_rsa -d" failed and exited with 1 during .
```

Some examples are:
 - https://travis-ci.org/ideatosrl/Idephix/jobs/83854184
 - https://travis-ci.org/ideatosrl/Idephix/jobs/124687633

I think we can remove this control, because creating a useless key it should not be a big problem.