### PR TITLE
replaces ConsoleOutput with SymfonyStyle class

### DIFF
--- a/docs/writing_tasks.rst
+++ b/docs/writing_tasks.rst
@@ -324,7 +324,7 @@ Writing output to the console
 -----------------------------
 
 Idephix is based on Symfony console component so you can send output to the user using the
-``\Symfony\Component\Console\Output\OutputInterface``. You can get the full ``OutputInterface`` component
+``\Symfony\Component\Console\Style\SymfonyStyle``. You can get the full ``SymfonyStyle`` component
 through the ``\Idephix\TaskExecutor::output`` method or you can use the shortcut methods:
 ``\Idephix\TaskExecutor::write`` and ``\Idephix\TaskExecutor::writeln``.
 
@@ -343,11 +343,31 @@ Here is an example of you you can send some output to the console.
     {
         $context->writeln(strtoupper($what));
         $context->write(strtoupper($what) . PHP_EOL);
-        $context->output()->write(strtoupper($what) . PHP_EOL);
-        $context->output()->writeln(strtoupper($what));
+
+        $output = $idx->output();
+
+        // common output elements
+        $output->title($what);
+        $output->section($what);
+        $output->text($what);
+        $output->comment($what);
+        $output->note($what);
+        $output->caution($what);
+        $output->listing([$what, $what, $what]);
+        $output->success($what);
+        $output->error($what);
+        $output->warning($what);
+
+        //table
+        $headers = ['Parameter', 'Value', 'Value 3'];
+        $rows = [
+          ['Param1', 'Value1', 'Value 3'],
+          ['Param2', 'Value2', 'Value 3']
+        ];
+        $output->table($headers, $rows);
     }
 
 .. hint::
 
-    For more information about ``OutputInterface`` read the official
-    component `documentation <http://symfony.com/doc/2.8/components/console.html>`_
+    For more information about ``SymfonyStyle`` read the official
+    component `documentation <http://symfony.com/blog/new-in-symfony-2-8-console-style-guide>`_

--- a/src/Idephix/Idephix.php
+++ b/src/Idephix/Idephix.php
@@ -14,6 +14,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\ArgvInput;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Output\ConsoleOutput;
+use Symfony\Component\Console\Style\SymfonyStyle;
 use Idephix\SSH\SshClient;
 use Idephix\Extension\IdephixAwareInterface;
 use Idephix\Task\Builtin\SelfUpdate;
@@ -60,8 +61,8 @@ class Idephix implements Builder, TaskExecutor
 
         $this->sshClient = $config['ssh_client'];
 
-        $this->output = $this->outputOrDefault($output);
         $this->input = $this->inputOrDefault($input);
+        $this->output = $this->outputOrDefault($output);
 
         $this->addSelfUpdateCommand();
         $this->addInitIdxFileCommand();
@@ -403,12 +404,12 @@ class Idephix implements Builder, TaskExecutor
 
     /**
      * @param OutputInterface $output
-     * @return ConsoleOutput|OutputInterface
+     * @return SymfonyStyle|OutputInterface
      */
     private function outputOrDefault(OutputInterface $output = null)
     {
         if (null === $output) {
-            $output = new ConsoleOutput();
+            $output = new SymfonyStyle($this->input, new ConsoleOutput());
         }
 
         return $output;


### PR DESCRIPTION
The PR allows to use [SymfonyStyle](http://symfony.com/blog/new-in-symfony-2-8-console-style-guide) class as default output instead of `ConsoleOutput`. 

The current build file does not allow to inject your own class even if `Idephix` class supports this parameter. Take a look to:

* [bootstrap.php](https://github.com/ideatosrl/Idephix/blob/master/src/Idephix/bootstrap.php#L37)
* [Idephix](https://github.com/ideatosrl/Idephix/blob/master/src/Idephix/Idephix.php#L47)

The `SymfonyStyle` class comes out with a lot of useful methods that improves output readability of our custom script. The [idxfile_custom.php.txt](https://github.com/ideatosrl/Idephix/files/705219/idxfile_custom.php.txt)
 attached is an example of how to use of these methods and the output should look like the following:

<img width="855" alt="schermata 2017-01-13 alle 20 57 39" src="https://cloud.githubusercontent.com/assets/485213/21943752/fe2f9df4-d9d2-11e6-8214-ab8479ed324c.png">

